### PR TITLE
Add CONTRIBUTING.md to project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# How to contribute
+
+Prerequisites:
+
+- Familiarity with [pull requests](https://help.github.com/articles/using-pull-requests) and [issues](https://guides.github.com/features/issues/).
+- Knowledge of [Markdown](https://help.github.com/articles/markdown-basics/) for editing `.md` documents.
+
+In particular, this community seeks the following types of contributions:
+
+- **Ideas**: participate in an issue thread or start your own to have your voice heard.
+- **Bug fixes**: bugs are inevitable, fixes are always welcome.
+- **New benchmarks**: add a new library benchmark to the collection with a pull request, or suggest one in an issue.
+
+# Conduct
+
+We are committed to providing a friendly, safe and welcoming environment for
+all, regardless of gender, sexual orientation, disability, ethnicity, religion,
+or similar personal characteristic.
+
+Please avoid using overtly sexual nicknames or other nicknames that
+might detract from a friendly, safe and welcoming environment for all.
+
+Please be kind and courteous. There's no need to be mean or rude.
+Respect that people have differences of opinion and that every design or
+implementation choice carries a trade-off and numerous costs. There is seldom
+a right answer, merely an optimal answer given a set of values and
+circumstances. Try to assume that our community members are nice people
+and remember, [miscommunication happens](https://hiddenbrain.org/podcast/why-conversations-go-wrong/).
+
+Please keep unstructured critique to a minimum. If you have solid ideas you
+want to experiment with, make a fork and see how it works.
+
+We will exclude you from interaction if you insult, demean or harass anyone.
+That is not welcome behaviour. We interpret the term "harassment" as
+including the definition in the [Code of Conduct](https://github.com/rock3r/bundel/blob/main/CODE_OF_CONDUCT.md);
+if you have any lack of clarity about what might be included in that concept,
+please read the definition. In particular, we don't tolerate behavior that
+excludes people in socially marginalized groups.
+
+Private harassment is also unacceptable. No matter who you are, if you feel
+you have been or are being harassed or made uncomfortable by a community
+member, please contact us [on Twitter](https://twitter.com/codewiththeita)
+immediately.
+Whether you're a regular contributor or a newcomer, we care about
+making this community a safe place for you and we've got your back.
+
+Likewise any spamming, trolling, flaming, baiting or other attention-stealing
+behaviour is not welcome.
+
+# Communication
+
+For generic communications, please reach out [on Twitter](https://twitter.com/codewiththeita)
+or in the comments during our regular [livestreams](http://bit.ly/cwi-twitch).
+
+GitHub issues are the primary way for communicating about specific proposed
+changes to this project.
+
+In both contexts, please follow the conduct guidelines above. Language issues
+are often contentious and we'd like to keep discussion brief, civil and focused
+on what we're actually doing, not wandering off into too much imaginary stuff.
+
+# Inspiration
+This guide is inspired to [Juno Suárez' contribution guidelines](https://github.com/junosuarez/CONTRIBUTING.md/blob/master/CONTRIBUTING.md),
+licensed under CC-0 license.


### PR DESCRIPTION
This is based on bundel's `CONTRIBUTING.md`, but it removed the live streaming references and the FAQ section as they aren't applicable here (FAQ might come back when we'll have some issues in the future).